### PR TITLE
speedy delivery

### DIFF
--- a/Plain.Courier.Core.Tests/Delivery/DeliveryCostsServiceHelper.cs
+++ b/Plain.Courier.Core.Tests/Delivery/DeliveryCostsServiceHelper.cs
@@ -6,9 +6,10 @@ using Plain.Courier.Core.Delivery.Services.Rules;
 
 namespace Plain.Courier.Core.Tests.Delivery {
    public static class DeliveryCostsServiceHelper {
-      public static List<Order> GetOrders_OneOfEach()
+      public static List<Order> GetOrders_OneOfEach(bool isSpeedy = false)
          => new List<Order>() {
          new Order() {
+            IsSpeedyDelivery = isSpeedy,
             Parcels = new List<Parcel>(){
                // small
                new Parcel() {
@@ -32,6 +33,9 @@ namespace Plain.Courier.Core.Tests.Delivery {
 
       public static List<IParcelDeliveryCostRule> CreateSimpleParcelRuleSet(AutoMock mock)
          => new List<IParcelDeliveryCostRule>() { mock.Create<SimpleParcelDeliveryCostRule>() };
+
+      public static List<IParcelDeliveryCostRule> CreateSpeedyParcelRuleSet(AutoMock mock)
+         => new List<IParcelDeliveryCostRule>() { mock.Create<SpeedyParcelDeliveryCostRule>() };
 
       public static AutoMock SetupRules(this AutoMock mock, List<IParcelDeliveryCostRule> ruleSets = null) {
          if (ruleSets != null) {

--- a/Plain.Courier.Core.Tests/Delivery/DeliveryCostsServiceHelper.cs
+++ b/Plain.Courier.Core.Tests/Delivery/DeliveryCostsServiceHelper.cs
@@ -35,7 +35,10 @@ namespace Plain.Courier.Core.Tests.Delivery {
          => new List<IParcelDeliveryCostRule>() { mock.Create<SimpleParcelDeliveryCostRule>() };
 
       public static List<IParcelDeliveryCostRule> CreateSpeedyParcelRuleSet(AutoMock mock)
-         => new List<IParcelDeliveryCostRule>() { mock.Create<SpeedyParcelDeliveryCostRule>() };
+         => new List<IParcelDeliveryCostRule>() {
+            mock.Create<SimpleParcelDeliveryCostRule>(),
+            mock.Create<SpeedyParcelDeliveryCostRule>()
+         };
 
       public static AutoMock SetupRules(this AutoMock mock, List<IParcelDeliveryCostRule> ruleSets = null) {
          if (ruleSets != null) {

--- a/Plain.Courier.Core.Tests/Delivery/DeliveryCostsServiceTests.cs
+++ b/Plain.Courier.Core.Tests/Delivery/DeliveryCostsServiceTests.cs
@@ -52,6 +52,7 @@ namespace Plain.Courier.Core.Tests.Delivery {
          // spedy order: small + med + large + xl ( 2* (3+8+15+25) = 2*51 = 102)
          Assert.IsTrue(result.Total == 153);
          Assert.IsTrue(result.ParcelSummary.Count == 8);
+         Assert.IsTrue(result.SpeedyDeliveries.Count == 4);
       }
    }
 }

--- a/Plain.Courier.Core.Tests/Delivery/DeliveryCostsServiceTests.cs
+++ b/Plain.Courier.Core.Tests/Delivery/DeliveryCostsServiceTests.cs
@@ -1,7 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Autofac.Extras.Moq;
 using NUnit.Framework;
+using Plain.Courier.Core.Delivery.Models;
 using Plain.Courier.Core.Delivery.Services;
 using static Plain.Courier.Core.Tests.Delivery.DeliveryCostsServiceHelper;
 
@@ -30,6 +33,25 @@ namespace Plain.Courier.Core.Tests.Delivery {
          // small + med + large + xl ( 3+8+15+25 = 51) 
          Assert.IsTrue(result.Total == 51);
          Assert.IsTrue(result.ParcelSummary.Count == 4);
+      }
+
+      [Test]
+      public void DeliveryForOrder_WithSpeedySetOfRules_OK() {
+         var orders = new List<Order>();
+         orders.AddRange(GetOrders_OneOfEach());
+         orders.AddRange(GetOrders_OneOfEach(isSpeedy: true));
+
+         var mock = GetMock();
+         var service = mock
+               .SetupRules(CreateSpeedyParcelRuleSet(mock))
+            .Create<DeliveryCostsService>();
+
+         var result = service.ComputeCost(orders);
+
+         // normal order: small + med + large + xl ( 3+8+15+25 = 51)
+         // spedy order: small + med + large + xl ( 2* (3+8+15+25) = 2*51 = 102)
+         Assert.IsTrue(result.Total == 153);
+         Assert.IsTrue(result.ParcelSummary.Count == 8);
       }
    }
 }

--- a/Plain.Courier.Core/Delivery/Models/DeliveryTotal.cs
+++ b/Plain.Courier.Core/Delivery/Models/DeliveryTotal.cs
@@ -1,18 +1,21 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace Plain.Courier.Core.Delivery.Models {
    public class DeliveryTotal {
       public decimal Total { get; set; }
       public List<ParcelDeliverySummary> ParcelSummary { get; set; } = new List<ParcelDeliverySummary>();
+      public IReadOnlyCollection<ParcelDeliverySummary> SpeedyDeliveries
+         => ParcelSummary?.Where(x => x.IsSpeedy == true).ToList().AsReadOnly();
    }
 
    public static class DeliveryTotalHelper {
       public static DeliveryTotal AddParcelSummary(this DeliveryTotal dt, ParcelDeliverySummary parcelDeliverySummary) {
          if (parcelDeliverySummary != null) {
             dt.ParcelSummary.Add(parcelDeliverySummary);
-            dt.Total += parcelDeliverySummary.Price;
+            dt.Total += parcelDeliverySummary.Total;
          }
 
          return dt;

--- a/Plain.Courier.Core/Delivery/Models/Order.cs
+++ b/Plain.Courier.Core/Delivery/Models/Order.cs
@@ -4,6 +4,7 @@ using System.Text;
 
 namespace Plain.Courier.Core.Delivery.Models {
    public class Order {
+      public bool IsSpeedyDelivery { get; set; } = false;
       public List<Parcel> Parcels { get; set; }
    }
 }

--- a/Plain.Courier.Core/Delivery/Models/ParcelDeliverySummary.cs
+++ b/Plain.Courier.Core/Delivery/Models/ParcelDeliverySummary.cs
@@ -5,10 +5,30 @@ using Plain.Courier.Core.Delivery.Constants;
 
 namespace Plain.Courier.Core.Delivery.Models {
    public class ParcelDeliverySummary {
-      public decimal BasicDeliveryPrice { get; set; }
-      public decimal DeliveryPriceFactor { get; set; } = 1;
+      public decimal? Price { get; set; }
+      public decimal? PriceFactor { get; set; }
+      public bool? IsSpeedy { get; set; }
 
-      public ParcelSize ParcelSize { get; set; }
-      public decimal Price { get => BasicDeliveryPrice * DeliveryPriceFactor; }
+      public ParcelSize? ParcelSize { get; set; }
+      public decimal Total { get => (Price ?? 0) * (PriceFactor ?? 1); }
+   }
+
+   public static class ParcelDeliverySummaryHelper {
+      public static ParcelDeliverySummary Update(this ParcelDeliverySummary parcelDeliverySummary, ParcelDeliverySummary right) {
+         if (right.Price.HasValue) {
+            parcelDeliverySummary.Price = right.Price;
+         }
+         if (right.PriceFactor.HasValue) {
+            parcelDeliverySummary.PriceFactor = right.PriceFactor;
+         }
+         if (right.IsSpeedy.HasValue) {
+            parcelDeliverySummary.IsSpeedy = right.IsSpeedy;
+         }
+         if (right.ParcelSize.HasValue) {
+            parcelDeliverySummary.ParcelSize = right.ParcelSize;
+         }
+
+         return parcelDeliverySummary;
+      }
    }
 }

--- a/Plain.Courier.Core/Delivery/Models/ParcelDeliverySummary.cs
+++ b/Plain.Courier.Core/Delivery/Models/ParcelDeliverySummary.cs
@@ -5,7 +5,10 @@ using Plain.Courier.Core.Delivery.Constants;
 
 namespace Plain.Courier.Core.Delivery.Models {
    public class ParcelDeliverySummary {
+      public decimal BasicDeliveryPrice { get; set; }
+      public decimal DeliveryPriceFactor { get; set; } = 1;
+
       public ParcelSize ParcelSize { get; set; }
-      public decimal Price { get; set; }
+      public decimal Price { get => BasicDeliveryPrice * DeliveryPriceFactor; }
    }
 }

--- a/Plain.Courier.Core/Delivery/Services/DeliveryCostsService.cs
+++ b/Plain.Courier.Core/Delivery/Services/DeliveryCostsService.cs
@@ -16,9 +16,13 @@ namespace Plain.Courier.Core.Delivery.Services {
          var output = new DeliveryTotal();
          orders?.ForEach(order => {
             order?.Parcels.ForEach(parcel => {
+               var parcelSummary = new ParcelDeliverySummary();
+
                _rules?.ForEach(rule => {
-                  output = output.AddParcelSummary(rule.GetCost(order, parcel));
+                  parcelSummary = parcelSummary.Update(rule.GetCost(order, parcel));
                });
+
+               output = output.AddParcelSummary(parcelSummary);
             });
          });
 

--- a/Plain.Courier.Core/Delivery/Services/Rules/SimpleParcelDeliveryCostRule.cs
+++ b/Plain.Courier.Core/Delivery/Services/Rules/SimpleParcelDeliveryCostRule.cs
@@ -20,7 +20,7 @@ namespace Plain.Courier.Core.Delivery.Services.Rules {
       public ParcelDeliverySummary GetCost(Order order, Parcel parcel) {
          var parcelType = GetParcelType(parcel);
          return new ParcelDeliverySummary() {
-            BasicDeliveryPrice = _prices[parcelType],
+            Price = _prices[parcelType],
             ParcelSize = parcelType
          };
       }

--- a/Plain.Courier.Core/Delivery/Services/Rules/SimpleParcelDeliveryCostRule.cs
+++ b/Plain.Courier.Core/Delivery/Services/Rules/SimpleParcelDeliveryCostRule.cs
@@ -20,7 +20,7 @@ namespace Plain.Courier.Core.Delivery.Services.Rules {
       public ParcelDeliverySummary GetCost(Order order, Parcel parcel) {
          var parcelType = GetParcelType(parcel);
          return new ParcelDeliverySummary() {
-            Price = _prices[parcelType],
+            BasicDeliveryPrice = _prices[parcelType],
             ParcelSize = parcelType
          };
       }

--- a/Plain.Courier.Core/Delivery/Services/Rules/SpeedyParcelDeliveryCostRule.cs
+++ b/Plain.Courier.Core/Delivery/Services/Rules/SpeedyParcelDeliveryCostRule.cs
@@ -6,7 +6,11 @@ using Plain.Courier.Core.Delivery.Models;
 namespace Plain.Courier.Core.Delivery.Services.Rules {
    public class SpeedyParcelDeliveryCostRule : IParcelDeliveryCostRule {
       public ParcelDeliverySummary GetCost(Order order, Parcel parcel) {
-         throw new NotImplementedException();
+         var isSpeedy = order?.IsSpeedyDelivery ?? false;
+         return new ParcelDeliverySummary() {
+            PriceFactor = isSpeedy ? 2 : 1,
+            IsSpeedy = isSpeedy
+         };
       }
    }
 }

--- a/Plain.Courier.Core/Delivery/Services/Rules/SpeedyParcelDeliveryCostRule.cs
+++ b/Plain.Courier.Core/Delivery/Services/Rules/SpeedyParcelDeliveryCostRule.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Plain.Courier.Core.Delivery.Models;
+
+namespace Plain.Courier.Core.Delivery.Services.Rules {
+   public class SpeedyParcelDeliveryCostRule : IParcelDeliveryCostRule {
+      public ParcelDeliverySummary GetCost(Order order, Parcel parcel) {
+         throw new NotImplementedException();
+      }
+   }
+}


### PR DESCRIPTION
Thanks to logistics improvements we can deliver parcels faster. This means we can
charge more money. Speedy shipping can be selected by the user to take advantage of our
improvements.
● This doubles the cost of the entire order
● Speedy shipping should be listed as a separate item in the output, with its associated
cost
● Speedy shipping should not impact the price of individual parcels, i.e. their individual
cost should remain the same as it was before