### PR TITLE
add weight based costs to deliveries

### DIFF
--- a/Plain.Courier.Core.Tests/Delivery/DeliveryCostsServiceHelper.cs
+++ b/Plain.Courier.Core.Tests/Delivery/DeliveryCostsServiceHelper.cs
@@ -6,7 +6,7 @@ using Plain.Courier.Core.Delivery.Services.Rules;
 
 namespace Plain.Courier.Core.Tests.Delivery {
    public static class DeliveryCostsServiceHelper {
-      public static List<Order> GetOrders_OneOfEach(bool isSpeedy = false)
+      public static List<Order> GetOrderWithOneOfEach(bool isSpeedy = false)
          => new List<Order>() {
          new Order() {
             IsSpeedyDelivery = isSpeedy,
@@ -31,6 +31,31 @@ namespace Plain.Courier.Core.Tests.Delivery {
          }
      };
 
+      public static List<Order> GetOrderWithOneOfEachAndWeightExcess(bool isSpeedy = false)
+         => new List<Order>() {
+         new Order() {
+            IsSpeedyDelivery = isSpeedy,
+            Parcels = new List<Parcel>(){
+               // small + 2kg weight excess
+               new Parcel() {
+                  Width = 3, Height = 3 , Length = 3 ,Weight= 3
+               },
+               // medium + 2kg weight excess
+               new Parcel() {
+                  Width = 30, Height = 3 , Length = 3,Weight= 5
+               },
+               // large + 2kg weight excess
+               new Parcel() {
+                  Width = 30, Height = 60 , Length = 3, Weight = 8
+               },
+               // xl + 2kg weight excess
+               new Parcel() {
+                  Width = 100, Height = 60 , Length = 3, Weight = 12
+               }
+            }
+         }
+     };
+
       public static List<IParcelDeliveryCostRule> CreateSimpleParcelRuleSet(AutoMock mock)
          => new List<IParcelDeliveryCostRule>() { mock.Create<SimpleParcelDeliveryCostRule>() };
 
@@ -38,6 +63,13 @@ namespace Plain.Courier.Core.Tests.Delivery {
          => new List<IParcelDeliveryCostRule>() {
             mock.Create<SimpleParcelDeliveryCostRule>(),
             mock.Create<SpeedyParcelDeliveryCostRule>()
+         };
+
+      public static List<IParcelDeliveryCostRule> CreateWeigthParcelRuleSet(AutoMock mock)
+         => new List<IParcelDeliveryCostRule>() {
+            mock.Create<SimpleParcelDeliveryCostRule>(),
+            mock.Create<SpeedyParcelDeliveryCostRule>(),
+            mock.Create<WeigthParcelDeliveryCostRule>()
          };
 
       public static AutoMock SetupRules(this AutoMock mock, List<IParcelDeliveryCostRule> ruleSets = null) {

--- a/Plain.Courier.Core.Tests/Delivery/DeliveryCostsServiceTests.cs
+++ b/Plain.Courier.Core.Tests/Delivery/DeliveryCostsServiceTests.cs
@@ -21,7 +21,7 @@ namespace Plain.Courier.Core.Tests.Delivery {
 
       [Test]
       public void DeliveryForOrder_WithSimpleSetOfRules_OK() {
-         var orders = GetOrders_OneOfEach();
+         var orders = GetOrderWithOneOfEach();
 
          var mock = GetMock();
          var service = mock
@@ -38,8 +38,8 @@ namespace Plain.Courier.Core.Tests.Delivery {
       [Test]
       public void DeliveryForOrder_WithSpeedySetOfRules_OK() {
          var orders = new List<Order>();
-         orders.AddRange(GetOrders_OneOfEach());
-         orders.AddRange(GetOrders_OneOfEach(isSpeedy: true));
+         orders.AddRange(GetOrderWithOneOfEach());
+         orders.AddRange(GetOrderWithOneOfEach(isSpeedy: true));
 
          var mock = GetMock();
          var service = mock
@@ -53,6 +53,26 @@ namespace Plain.Courier.Core.Tests.Delivery {
          Assert.IsTrue(result.Total == 153);
          Assert.IsTrue(result.ParcelSummary.Count == 8);
          Assert.IsTrue(result.SpeedyDeliveries.Count == 4);
+      }
+
+      [Test]
+      public void DeliveryForOrder_WithWeightSetOfRules_OK() {
+         var orders = new List<Order>();
+         orders.AddRange(GetOrderWithOneOfEachAndWeightExcess());
+         orders.AddRange(GetOrderWithOneOfEachAndWeightExcess(isSpeedy: true));
+
+         var mock = GetMock();
+         var service = mock
+               .SetupRules(CreateWeigthParcelRuleSet(mock))
+            .Create<DeliveryCostsService>();
+
+         var result = service.ComputeCost(orders);
+
+         // normal order: small + med + large + xl ( 3+8+15+25 = 51)
+         // + 4 * 4 (all parcels ar by definition in excess of 2 kg , thus an extra 4$
+         // total 51 + 16 = 67
+         // one normal setup + 2x (as the 2n one is speedy) => 67*3;
+         Assert.IsTrue(result.Total == 67 * 3);
       }
    }
 }

--- a/Plain.Courier.Core/Delivery/Models/Parcel.cs
+++ b/Plain.Courier.Core/Delivery/Models/Parcel.cs
@@ -7,6 +7,7 @@ namespace Plain.Courier.Core.Delivery.Models {
       public int Length { get; set; }
       public int Width { get; set; }
       public int Height { get; set; }
+      public int Weight { get; set; } = 0;
 
       public List<int> Dimensions => new List<int>() { Length, Width, Height };
    }

--- a/Plain.Courier.Core/Delivery/Models/ParcelDeliverySummary.cs
+++ b/Plain.Courier.Core/Delivery/Models/ParcelDeliverySummary.cs
@@ -16,7 +16,7 @@ namespace Plain.Courier.Core.Delivery.Models {
    public static class ParcelDeliverySummaryHelper {
       public static ParcelDeliverySummary Update(this ParcelDeliverySummary parcelDeliverySummary, ParcelDeliverySummary right) {
          if (right.Price.HasValue) {
-            parcelDeliverySummary.Price = right.Price;
+            parcelDeliverySummary.Price = (parcelDeliverySummary.Price ?? 0) + right.Price;
          }
          if (right.PriceFactor.HasValue) {
             parcelDeliverySummary.PriceFactor = right.PriceFactor;

--- a/Plain.Courier.Core/Delivery/Services/Rules/BaseParcelRuleSet.cs
+++ b/Plain.Courier.Core/Delivery/Services/Rules/BaseParcelRuleSet.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Plain.Courier.Core.Delivery.Constants;
+using Plain.Courier.Core.Delivery.Models;
+using static Plain.Courier.Core.Delivery.Constants.ParcelSize;
+
+namespace Plain.Courier.Core.Delivery.Services.Rules {
+   public abstract class BaseParcelRuleSet {
+      internal ParcelSize GetParcelType(Parcel parcel) {
+         // not a nice way to handle as we evaluate the collection way to many times ,but for the sake of the exercise 
+         // is considered to be accepted 
+         if (parcel?.Dimensions?.All(x => x < 10) ?? false) {
+            return Small;
+         }
+
+         if (parcel?.Dimensions?.All(x => x < 50) ?? false) {
+            return Medium;
+         }
+
+         if (parcel?.Dimensions?.All(x => x < 100) ?? false) {
+            return Large;
+         }
+
+         if (parcel.Dimensions?.Any(x => x >= 100) ?? false) {
+            return XL;
+         }
+
+         // we dont know it then it is free ... :P
+         return Unknown;
+      }
+   }
+}

--- a/Plain.Courier.Core/Delivery/Services/Rules/SimpleParcelDeliveryCostRule.cs
+++ b/Plain.Courier.Core/Delivery/Services/Rules/SimpleParcelDeliveryCostRule.cs
@@ -7,7 +7,7 @@ using Plain.Courier.Core.Delivery.Models;
 using static Plain.Courier.Core.Delivery.Constants.ParcelSize;
 
 namespace Plain.Courier.Core.Delivery.Services.Rules {
-   public class SimpleParcelDeliveryCostRule : IParcelDeliveryCostRule {
+   public class SimpleParcelDeliveryCostRule : BaseParcelRuleSet, IParcelDeliveryCostRule {
 
       private readonly Dictionary<ParcelSize, decimal> _prices = new Dictionary<ParcelSize, decimal>() {
          [Unknown] = 0,
@@ -23,29 +23,6 @@ namespace Plain.Courier.Core.Delivery.Services.Rules {
             Price = _prices[parcelType],
             ParcelSize = parcelType
          };
-      }
-
-      private ParcelSize GetParcelType(Parcel parcel) {
-         // not a nice way to handle as we evaluate the collection way to many times ,but for the sake of the exercise 
-         // is considered to be accepted 
-         if (parcel?.Dimensions?.All(x => x < 10) ?? false) {
-            return Small;
-         }
-
-         if (parcel?.Dimensions?.All(x => x < 50) ?? false) {
-            return Medium;
-         }
-
-         if (parcel?.Dimensions?.All(x => x < 100) ?? false) {
-            return Large;
-         }
-
-         if (parcel.Dimensions?.Any(x => x >= 100) ?? false) {
-            return XL;
-         }
-
-         // we dont know it then it is free ... :P
-         return Unknown;
       }
    }
 }

--- a/Plain.Courier.Core/Delivery/Services/Rules/SpeedyParcelDeliveryCostRule.cs
+++ b/Plain.Courier.Core/Delivery/Services/Rules/SpeedyParcelDeliveryCostRule.cs
@@ -4,7 +4,7 @@ using System.Text;
 using Plain.Courier.Core.Delivery.Models;
 
 namespace Plain.Courier.Core.Delivery.Services.Rules {
-   public class SpeedyParcelDeliveryCostRule : IParcelDeliveryCostRule {
+   public class SpeedyParcelDeliveryCostRule : BaseParcelRuleSet, IParcelDeliveryCostRule {
       public ParcelDeliverySummary GetCost(Order order, Parcel parcel) {
          var isSpeedy = order?.IsSpeedyDelivery ?? false;
          return new ParcelDeliverySummary() {

--- a/Plain.Courier.Core/Delivery/Services/Rules/WeigthParcelDeliveryCostRule.cs
+++ b/Plain.Courier.Core/Delivery/Services/Rules/WeigthParcelDeliveryCostRule.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Plain.Courier.Core.Delivery.Constants;
+using Plain.Courier.Core.Delivery.Models;
+using static Plain.Courier.Core.Delivery.Constants.ParcelSize;
+
+namespace Plain.Courier.Core.Delivery.Services.Rules {
+   public class WeigthParcelDeliveryCostRule : BaseParcelRuleSet, IParcelDeliveryCostRule {
+
+      private readonly Dictionary<ParcelSize, decimal> _weigthLimits = new Dictionary<ParcelSize, decimal>() {
+         [Unknown] = int.MaxValue,
+         [Small] = 1,
+         [Medium] = 3,
+         [Large] = 6,
+         [XL] = 10
+      };
+
+      public const decimal ExcessPriceCost = 2;
+
+      public ParcelDeliverySummary GetCost(Order order, Parcel parcel) {
+         var type = GetParcelType(parcel);
+         var limit = _weigthLimits[type];
+         var excessWeight = (parcel?.Weight ?? 0) - limit;
+         var extraCost = excessWeight > 0 ? (decimal?)(excessWeight * ExcessPriceCost) : null;
+         return new ParcelDeliverySummary() {
+            Price = extraCost
+         };
+      }
+   }
+}


### PR DESCRIPTION
There have been complaints from delivery drivers that people are taking advantage of our
dimension only shipping costs. A new weight limit has been added for each parcel type, over
which a charge per kg of weight applies
+$2/kg over weight limit for parcel size:
● Small parcel: 1kg
● Medium parcel: 3kg
● Large parcel: 6kg
● XL parcel: 10kg